### PR TITLE
fix: missing return statement added

### DIFF
--- a/libraries/SuplaDevice/SuplaDevice.cpp
+++ b/libraries/SuplaDevice/SuplaDevice.cpp
@@ -165,7 +165,8 @@ bool SuplaDeviceClass::suplaDigitalRead_isHI(int channelNumber, uint8_t pin) {
 void SuplaDeviceClass::suplaDigitalWrite(int channelNumber, uint8_t pin, uint8_t val) {
 	
 	if ( impl_arduino_digitalWrite != NULL )
-		 impl_arduino_digitalWrite(channelNumber, pin, val);
+		 return impl_arduino_digitalWrite(channelNumber, pin, val);
+
 	
 	digitalWrite(pin, val);
 	


### PR DESCRIPTION
Missing return caused custom digital write function to be ignored.

As I understand, if custom digital write function is provided by user, default one shall not be used.